### PR TITLE
Julia 0.7 Compatability

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - linux
   # - osx
 julia:
-  - 0.6
+  - 0.7
   - nightly
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,6 @@ notifications:
   email: false
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - julia --check-bounds=yes -e 'Pkg.clone(pwd()); Pkg.test("Vec"; coverage=true)'
+  - julia --check-bounds=yes -e 'using Pkg; Pkg.add(pwd()); Pkg.test("Vec"; coverage=true)'
 after_success:
-  - julia -e 'cd(Pkg.dir("Vec")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
+  - julia -e 'using Pkg; cd(Pkg.dir("Vec")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.6
+julia 0.7
 StaticArrays

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,3 @@
 julia 0.7
 StaticArrays
+LinearAlgebra

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,2 @@
 julia 0.7
 StaticArrays
-LinearAlgebra

--- a/src/Vec.jl
+++ b/src/Vec.jl
@@ -3,6 +3,7 @@ __precompile__()
 module Vec
 
 using StaticArrays
+import Printf: @printf
 
 export
     AbstractVec,

--- a/src/Vec.jl
+++ b/src/Vec.jl
@@ -3,7 +3,9 @@ __precompile__()
 module Vec
 
 using StaticArrays
+import LinearAlgebra
 import Printf: @printf
+import LinearAlgebra: ⋅, ×
 
 export
     AbstractVec,

--- a/src/coordinate_transforms.jl
+++ b/src/coordinate_transforms.jl
@@ -131,13 +131,12 @@ end
 Base.convert(::Type{VecE3}, p::ECEF) = VecE3(p.x, p.y, p.z)
 Base.convert(::Type{ECEF}, p::VecE3) = ECEF(p.x, p.y, p.z)
 
-"""
-Universal Transverse Mercator coordinate system
-"""
-
 const UTM_LATITUDE_LIMIT_NORTH = deg2rad(84)
 const UTM_LATITUDE_LIMIT_SOUTH = deg2rad(-80)
 
+"""
+Universal Transverse Mercator coordinate system
+"""
 struct UTM <: AbstractCoordinate
     e::Float64 # [m]
     n::Float64 # [m]
@@ -264,9 +263,9 @@ function Base.convert(::Type{UTM}, lla::LatLonAlt, datum::GeodeticDatum=WGS_84, 
         error("latitude $(rad2deg(lat)) is out of limits!")
     end
 
-    const FN = 0.0      # false northing, zero in the northern hemisphere
-    const FE = 500000.0 # false easting
-    const ko = 0.9996   # central scale factor
+    FN = 0.0      # false northing, zero in the northern hemisphere
+    FE = 500000.0 # false easting
+    ko = 0.9996   # central scale factor
 
     zone_centers = -177.0*pi/180 + 6.0*pi/180*collect(0:59) # longitudes of the zone centers
     if zone == -1

--- a/src/coordinate_transforms.jl
+++ b/src/coordinate_transforms.jl
@@ -267,21 +267,21 @@ function Base.convert(::Type{UTM}, lla::LatLonAlt, datum::GeodeticDatum=WGS_84, 
     FE = 500000.0 # false easting
     ko = 0.9996   # central scale factor
 
-    zone_centers = -177.0*pi/180 + 6.0*pi/180*collect(0:59) # longitudes of the zone centers
+    zone_centers = collect(0:59).*(6.0*π/180) .- (177.0*π/180) # longitudes of the zone centers
     if zone == -1
-        zone = indmin(map(x->abs(lon - x), zone_centers)) # index of min zone center
+        zone = argmin(map(x->abs(lon - x), zone_centers)) # index of min zone center
     end
     long0 = zone_centers[zone]
 
-    s  = sin(lat)
-    c  = cos(lat)
-    t  = tan(lat)
+    s = sin(lat)
+    c = cos(lat)
+    t = tan(lat)
 
     a = datum.a
     b = datum.b
 
     n  = (a-b)/(a+b)
-    e₁  = sqrt((a^2-b^2)/a^2) # first eccentricity
+    e₁ = sqrt((a^2-b^2)/a^2) # first eccentricity
     ep = sqrt((a^2-b^2)/b^2) # second eccentricity
     nu = a/(1-e₁^2*s^2)^0.5   # radius of curvature in the prime vertical
     dh = lon - long0         # longitudinal distance from central meridian

--- a/src/geom/hyperplanes.jl
+++ b/src/geom/hyperplanes.jl
@@ -22,39 +22,39 @@ struct Plane3
     Constructs a plane from its normal n and distance to the origin d
     such that the algebraic equation of the plane is n⋅x + d = 0.
     """
-    Plane3(normal::VecE3, offset::Real) = new(normalize(normal), convert(Float64, offset))
+    Plane3(normal::VecE3, offset::Real) = new(LinearAlgebra.normalize(normal), convert(Float64, offset))
 
 
     """
     Construct a plane from its normal and a point on the plane.
     """
     function Plane3(normal::VecE3, P::VecE3)
-        n = normalize(normal)
+        n = LinearAlgebra.normalize(normal)
         offset = -n⋅P
         return new(n, offset)
     end
 end
 
 """
-Constructs a plane passing through the three points. 
+Constructs a plane passing through the three points.
 """
 function Plane3(p0::VecE3, p1::VecE3, p2::VecE3)
     v0 = p2 - p0
     v1 = p1 - p0
 
     normal = v0×v1
-    nnorm = norm(normal)
-    if nnorm <= norm(v0)*norm(v1)*eps()
+    nnorm = LinearAlgebra.norm(normal)
+    if nnorm <= LinearAlgebra.norm(v0)*LinearAlgebra.norm(v1)*eps()
         M = hcat(convert(Vector{Float64}, v0),
                  convert(Vector{Float64}, v1))'
-        s = svdfact(M, thin=false)
+        s = LinearAlgebra.svdfact(M, thin=false)
         normal = convert(VecE3, s[:V][:,2])
     else
-        normal = normalize(normal)
+        normal = LinearAlgebra.normalize(normal)
     end
-    
+
     offset = -p0⋅normal
-    
+
     return Plane3(normal, offset)
 end
 

--- a/src/geom/line_segments.jl
+++ b/src/geom/line_segments.jl
@@ -26,14 +26,14 @@ function get_distance(seg::LineSegment, P::VecE2)
         return 0.0
     end
 
-    r = dot(ab, pb)/denom
+    r = (ab⋅pb)/denom
 
     if r ≤ 0.0
-        norm(P - seg.A)
+        LinearAlgebra.norm(P - seg.A)
     elseif r ≥ 1.0
-        norm(P - seg.B)
+        LinearAlgebra.norm(P - seg.B)
     else
-        norm(P - (seg.A + r*ab))
+        LinearAlgebra.norm(P - (seg.A + r*ab))
     end
 end
 
@@ -49,11 +49,11 @@ The angular distance between the two line segments
 function angledist(segA::LineSegment, segB::LineSegment)
     u = segA.B - segA.A
     v = segB.B - segB.A
-    sqdenom = dot(u,u)*dot(v,v)
+    sqdenom = (u⋅u)*(v⋅v)
     if isapprox(sqdenom, 0.0, atol=1e-10)
         return NaN
     end
-    return acos(dot(u,v) / sqrt(sqdenom))
+    return acos((u⋅v) / sqrt(sqdenom))
 end
 
 """

--- a/src/geom/lines.jl
+++ b/src/geom/lines.jl
@@ -32,8 +32,8 @@ function get_distance(line::Line, P::VecE2)
         return 0.0
     end
 
-    r = dot(ab, pb)/denom
-    return norm(P - (line.C + r*ab))
+    r = (ab⋅pb)/denom
+    return LinearAlgebra.norm(P - (line.C + r*ab))
 end
 
 

--- a/src/geom/projectiles.jl
+++ b/src/geom/projectiles.jl
@@ -26,13 +26,13 @@ function closest_time_of_approach(A::Projectile, B::Projectile)
     if aΔ ≈ 0.0
         return 0.0
     else
-        return -dot(W, Δ) / aΔ
+        return -(W⋅Δ) / aΔ
     end
 end
 function closest_approach_distance(A::Projectile, B::Projectile, t_CPA::Float64=closest_time_of_approach(A, B))
     Aₜ = convert(VecE2, propagate(A, t_CPA).pos)
     Bₜ = convert(VecE2, propagate(B, t_CPA).pos)
-    return norm(Aₜ - Bₜ)
+    return LinearAlgebra.norm(Aₜ - Bₜ)
 end
 function closest_time_of_approach_and_distance(A::Projectile, B::Projectile)
     t_CPA = closest_time_of_approach(A, B)
@@ -47,11 +47,11 @@ function get_intersection_time(A::Projectile, seg::LineSegment)
     v₂ = seg.B - seg.A
     v₃ = polar(1.0, A.pos.θ + π/2)
 
-    denom = dot(v₂, v₃)
+    denom = (v₂⋅v₃)
 
     if !isapprox(denom, 0.0, atol=1e-10)
-        d₁ = cross(v₂, v₁) / denom # time for projectile (0 ≤ t₁)
-        t₂ = dot(v₁, v₃) / denom # time for segment (0 ≤ t₂ ≤ 1)
+        d₁ = (v₂×v₁) / denom # time for projectile (0 ≤ t₁)
+        t₂ = (v₁⋅v₃) / denom # time for segment (0 ≤ t₂ ≤ 1)
         if 0.0 ≤ d₁ && 0.0 ≤ t₂ ≤ 1.0
             return d₁/A.v
         end
@@ -74,12 +74,12 @@ function closest_time_of_approach_and_distance(P::Projectile, seg::LineSegment, 
     v₂ = seg.B - seg.A
     v₃ = polar(1.0, P.pos.θ + π/2)
 
-    denom = dot(v₂, v₃)
+    denom = (v₂⋅v₃)
 
     if !isapprox(denom, 0.0, atol=1e-10)
 
-        d₁ = cross(v₂, v₁) / denom # time for projectile (0 ≤ d₁)
-        t₂ = dot(v₁, v₃) / denom # time for segment (0 ≤ t₂ ≤ 1)
+        d₁ = (v₂×v₁) / denom # time for projectile (0 ≤ d₁)
+        t₂ = (v₁⋅v₃) / denom # time for segment (0 ≤ t₂ ≤ 1)
 
         if 0.0 ≤ d₁ && 0.0 ≤ t₂ ≤ 1.0
             t = d₁/P.v
@@ -90,8 +90,8 @@ function closest_time_of_approach_and_distance(P::Projectile, seg::LineSegment, 
                 r = polar(1.0, P.pos.θ)
                 projA = proj(seg.A - o, r, VecE2)
                 projB = proj(seg.B - o, r, VecE2)
-                tA = max(norm(projA)/P.v * sign(dot(r, projA)), 0.0)
-                tB = max(norm(projB)/P.v * sign(dot(r, projB)), 0.0)
+                tA = max(LinearAlgebra.norm(projA)/P.v * sign(r⋅projA), 0.0)
+                tB = max(LinearAlgebra.norm(projB)/P.v * sign(r⋅projB), 0.0)
                 pA = VecE2(propagate(P, tA).pos)
                 pB = VecE2(propagate(P, tB).pos)
                 distA = normsquared(seg.A - pA)
@@ -121,8 +121,8 @@ function closest_time_of_approach_and_distance(P::Projectile, seg::LineSegment, 
                 r = polar(1.0, P.pos.θ)
                 projA = proj(seg.A - o, r, VecE2)
                 projB = proj(seg.B - o, r, VecE2)
-                tA = max(norm(projA)/P.v * sign(dot(r, projA)), 0.0)
-                tB = max(norm(projB)/P.v * sign(dot(r, projB)), 0.0)
+                tA = max(LinearAlgebra.norm(projA)/P.v * sign(r⋅projA), 0.0)
+                tB = max(LinearAlgebra.norm(projB)/P.v * sign(r⋅projB), 0.0)
                 pA = VecE2(propagate(P, tA).pos)
                 pB = VecE2(propagate(P, tB).pos)
                 distA = normsquared(seg.A - pA)

--- a/src/geom/rays.jl
+++ b/src/geom/rays.jl
@@ -30,11 +30,10 @@ function intersects(ray::Ray, line::Line;
     v₂ = polar(1.0, line.θ)
     v₃ = polar(1.0, ray.θ + π/2)
 
-    denom = dot(v₂, v₃)
+    denom = v₂⋅v₃
 
     if !(denom ≈ 0.0)
-        t₁ = cross(v₂, v₁) / denom # time for ray (0 ≤ t₁)
-        # t₂ = dot(v₁, v₃) / denom # time for line can be anything
+        t₁ = (v₂×v₁) / denom # time for ray (0 ≤ t₁)
         return -ε ≤ t₁
     else
         # denom is zero if the line and the ray are parallel
@@ -48,11 +47,11 @@ function intersects(ray::Ray, seg::LineSegment)
     v₂ = seg.B - seg.A
     v₃ = polar(1.0, ray.θ + π/2)
 
-    denom = dot(v₂, v₃)
+    denom = v₂⋅v₃
 
     if !isapprox(denom, 0.0, atol=1e-10)
-        t₁ = cross(v₂, v₁) / denom # time for ray (0 ≤ t₁)
-        t₂ = dot(v₁, v₃) / denom # time for segment (0 ≤ t₂ ≤ 1)
+        t₁ = (v₂×v₁) / denom # time for ray (0 ≤ t₁)
+        t₂ = (v₁⋅v₃) / denom # time for segment (0 ≤ t₂ ≤ 1)
         return 0 ≤ t₁ && 0 ≤ t₂ ≤ 1
     else
         # denom is zero if the segment and the ray are parallel
@@ -60,7 +59,7 @@ function intersects(ray::Ray, seg::LineSegment)
         # must ensure that at least one point is in the positive ray direction
         r = polar(1.0, ray.θ)
         return are_collinear(R, seg.A, seg.B) &&
-               (dot(r, seg.A - R) ≥ 0 || dot(r, seg.B - R) ≥ 0)
+               (r⋅(seg.A - R) ≥ 0 || r⋅(seg.B - R) ≥ 0)
     end
 end
 
@@ -95,11 +94,11 @@ function Base.intersect(ray::Ray, seg::LineSegment)
     v₂ = seg.B - seg.A
     v₃ = polar(1.0, ray.θ + π/2)
 
-    denom = dot(v₂, v₃)
+    denom = v₂⋅v₃
 
     if !isapprox(denom, 0.0, atol=1e-10)
-        t₁ = cross(v₂, v₁) / denom # time for ray (0 ≤ t₁)
-        t₂ = dot(v₁, v₃) / denom # time for segment (0 ≤ t₂ ≤ 1)
+        t₁ = (v₂×v₁) / denom # time for ray (0 ≤ t₁)
+        t₂ = (v₁⋅v₃) / denom # time for segment (0 ≤ t₂ ≤ 1)
         if 0 ≤ t₁ && 0 ≤ t₂ ≤ 1
             return R + polar(t₁, ray.θ)
         end
@@ -109,7 +108,7 @@ function Base.intersect(ray::Ray, seg::LineSegment)
         # must ensure that at least one point is in the positive ray direction
         r = polar(1.0, ray.θ)
         if are_collinear(R, seg.A, seg.B) &&
-               (dot(r, seg.A - R) ≥ 0 || dot(r, seg.B - R) ≥ 0)
+               (r⋅(seg.A - R) ≥ 0 || r⋅(seg.B - R) ≥ 0)
             return R
         end
     end

--- a/src/geom/rays.jl
+++ b/src/geom/rays.jl
@@ -23,7 +23,7 @@ function intersects(A::Ray, B::Ray)
     return u > 0.0 && v > 0.0
 end
 function intersects(ray::Ray, line::Line;
-    ε::Float64 = 1e-10;
+    ε::Float64 = 1e-10,
     )
 
     v₁ = VecE2(ray) - line.C

--- a/src/quat.jl
+++ b/src/quat.jl
@@ -73,7 +73,7 @@ The angle (in radians) between two rotations
 """
 function angledist(a::Quat, b::Quat)
     d = a * conj(b)
-    return 2*atan2(norm(imag(d)), abs(d.w))
+    return 2*atan2(LinearAlgebra.norm(imag(d)), abs(d.w))
 end
 
 """
@@ -81,8 +81,8 @@ The quaternion that transforms a into b through a rotation
 Based on Eigen's implementation for setFromTwoVectors
 """
 function quat_for_a2b(a::VecE3, b::VecE3)
-    v0 = normalize(a)
-    v1 = normalize(b)
+    v0 = LinearAlgebra.normalize(a)
+    v1 = LinearAlgebra.normalize(b)
     c = v1⋅v0
 
     # if dot == -1, vectors are nearly opposites
@@ -97,7 +97,7 @@ function quat_for_a2b(a::VecE3, b::VecE3)
         c = max(c, -1.0)
         M = hcat(convert(Vector{Float64}, v0),
                  convert(Vector{Float64}, v1))'
-        s = svdfact(M, thin=false)
+        s = LinearAlgebra.svdfact(M, thin=false)
         axis = convert(VecE3, s[:V][:,2])
         w2 = (1.0 + c)*0.5
         return Quat(axis * sqrt(1.0 - w2), sqrt(w2))
@@ -116,7 +116,7 @@ a and b for t ∈ [0,1].
 Based on the Eigen implementation for slerp.
 """
 function lerp(a::Quat, b::Quat, t::Float64)
-  
+
     d = a⋅b
     absD = abs(d)
 
@@ -182,7 +182,7 @@ struct RPY <: FieldVector{3, Float64}
 end
 function Base.convert(::Type{RPY}, q::Quat)
 
-    q2 = normalize(q)
+    q2 = LinearAlgebra.normalize(q)
     x = q2[1]
     y = q2[2]
     z = q2[3]
@@ -203,7 +203,7 @@ function Base.convert(::Type{RPY}, q::Quat)
 
     # yaw (z-axis rotation)
     siny = 2(w * z + x * y)
-    cosy = 1.0 - 2(y * y + z * z) 
+    cosy = 1.0 - 2(y * y + z * z)
     yaw = atan2(siny, cosy)
 
     RPY(roll, pitch, yaw)

--- a/src/vecSE2.jl
+++ b/src/vecSE2.jl
@@ -48,9 +48,9 @@ Base.:%(a::VecSE2, b::Real) = error(op_overload_error)
 scale_euclidean(a::VecSE2, b::Real) = VecSE2(b*a.x, b*a.y, a.θ)
 clamp_euclidean(a::VecSE2, lo::Real, hi::Real) = VecSE2(clamp(a.x, lo, hi), clamp(a.y, lo, hi), a.θ)
 
-Base.norm(a::VecSE2, p::Real=2) = error("norm is not defined for VecSE2 - use norm(VecE2(v)) to get the norm of the Euclidean part")
+norm(a::VecSE2, p::Real=2) = error("norm is not defined for VecSE2 - use norm(VecE2(v)) to get the norm of the Euclidean part")
 normsquared(a::VecSE2) = norm(a)^2 # this will correctly throw an error
-Base.normalize(a::VecSE2, p::Real=2) = error("normalize is not defined for VecSE2. Use normalize_euclidean(v) to normalize the euclidean part of the vector")
+normalize(a::VecSE2, p::Real=2) = error("normalize is not defined for VecSE2. Use normalize_euclidean(v) to normalize the euclidean part of the vector")
 
 function normalize_euclidian(a::VecSE2, p::Real=2)
     n = norm(VecE2(a))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,7 @@
 using Vec
 using Test
+import LinearAlgebra: norm, normalize, dot
+import Random: srand
 
 @test invlerp(0.0,1.0,0.5) ≈ 0.5
 @test invlerp(0.0,1.0,0.4) ≈ 0.4

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using Vec
-using Base.Test
+using Test
 
 @test invlerp(0.0,1.0,0.5) ≈ 0.5
 @test invlerp(0.0,1.0,0.4) ≈ 0.4

--- a/test/test_coordinate_transforms.jl
+++ b/test/test_coordinate_transforms.jl
@@ -61,8 +61,8 @@ let
     lla = LatLonAlt(0.1,0.2+2π,0.3)
     @test isapprox(ensure_lon_between_pies(lla).lon, 0.2, atol=1e-10)
 
-    @test isapprox(get_earth_radius(0.0), 6378137.0, atol=1e-8)
-    @test isapprox(get_earth_radius(π/2), 6356752.3, atol=1e-8)
+    @test isapprox(get_earth_radius(0.0), 6378137.0, atol=0.1)
+    @test isapprox(get_earth_radius(π/2), 6356752.3, atol=0.1)
 
     v3 = convert(VecE3, ECEF(0.1,0.2,0.3))
     @test v3.x == 0.1
@@ -125,5 +125,4 @@ let
         @test isapprox(ecef2.y, ecef.y, atol=1.0)
         @test isapprox(ecef2.z, ecef.z, atol=1.0)
     end
-
 end

--- a/test/test_diff.jl
+++ b/test/test_diff.jl
@@ -1,26 +1,29 @@
 using ForwardDiff
+using LinearAlgebra
 
-f(x) = x+x
-g(x) = 5*x
-h(x) = dot(x, x)
+let
+	f(x) = x+x
+	g(x) = 5*x
+	h(x) = dot(x, x)
 
-# Once we get ForwardDiff working, this should work
-# h(x::VecE) = dot(x, x)
+	# Once we get ForwardDiff working, this should work
+	# h(x::VecE) = dot(x, x)
 
-@test ForwardDiff.jacobian(f, VecE2(1.0, 2.0)) == [2.0 0.0; 0.0 2.0]
-@test ForwardDiff.jacobian(g, VecE2(1.0, 2.0)) == [5.0 0.0; 0.0 5.0]
-@test ForwardDiff.gradient(h, VecE2(1.0, 2.0)) == [2.0, 4.0]
-@test ForwardDiff.hessian(h, VecE2(1.0, 2.0)) == [2.0 0.0; 0.0 2.0]
+	@test ForwardDiff.jacobian(f, VecE2(1.0, 2.0)) == [2.0 0.0; 0.0 2.0]
+	@test ForwardDiff.jacobian(g, VecE2(1.0, 2.0)) == [5.0 0.0; 0.0 5.0]
+	@test ForwardDiff.gradient(h, VecE2(1.0, 2.0)) == [2.0, 4.0]
+	@test ForwardDiff.hessian(h, VecE2(1.0, 2.0)) == [2.0 0.0; 0.0 2.0]
 
-@test ForwardDiff.jacobian(f, VecE3(1.0, 2.0, 3.0)) == 2.0*eye(3)
-@test ForwardDiff.jacobian(g, VecE3(1.0, 2.0, 3.0)) == 5.0*eye(3)
-@test ForwardDiff.gradient(h, VecE3(1.0, 2.0, 3.0)) == [2.0, 4.0, 6.0]
-@test ForwardDiff.hessian(h, VecE3(1.0, 2.0, 3.0)) == 2.0*eye(3)
+	@test ForwardDiff.jacobian(f, VecE3(1.0, 2.0, 3.0)) == 2.0*Matrix{Float64}(I, 3, 3)
+	@test ForwardDiff.jacobian(g, VecE3(1.0, 2.0, 3.0)) == 5.0*Matrix{Float64}(I, 3, 3)
+	@test ForwardDiff.gradient(h, VecE3(1.0, 2.0, 3.0)) == [2.0, 4.0, 6.0]
+	@test ForwardDiff.hessian(h, VecE3(1.0, 2.0, 3.0)) == 2.0*Matrix{Float64}(I, 3, 3)
 
-@test ForwardDiff.jacobian(f, VecSE2(1.0, 2.0, 3.0)) == 2.0*eye(3)
+	@test ForwardDiff.jacobian(f, VecSE2(1.0, 2.0, 3.0)) == 2.0*Matrix{Float64}(I, 3, 3)
 
-# Once we get ForwardDiff working, this should work...
-# h(x::VecSE2) = normsquared(VecE2(x))
-# @test ForwardDiff.jacobian(g, VecSE2(1.0, 2.0, 3.0)) == diagm([5.0, 5.0, 1.0])
-# @test ForwardDiff.gradient(h, VecSE2(1.0, 2.0, 3.0)) == [2.0, 4.0, 0.0]
-# @test ForwardDiff.hessian(h, VecSE2(1.0, 2.0, 3.0)) == [2.0 0.0 0.0; 0.0 2.0 0.0; 0.0 0.0 0.0]
+	# Once we get ForwardDiff working, this should work...
+	# h(x::VecSE2) = normsquared(VecE2(x))
+	# @test ForwardDiff.jacobian(g, VecSE2(1.0, 2.0, 3.0)) == diagm([5.0, 5.0, 1.0])
+	# @test ForwardDiff.gradient(h, VecSE2(1.0, 2.0, 3.0)) == [2.0, 4.0, 0.0]
+	# @test ForwardDiff.hessian(h, VecSE2(1.0, 2.0, 3.0)) == [2.0 0.0 0.0; 0.0 2.0 0.0; 0.0 0.0 0.0]
+end

--- a/test/test_geomE2.jl
+++ b/test/test_geomE2.jl
@@ -1,23 +1,25 @@
-@test isapprox(deltaangle(0.0, 0.0),  0.0)
-@test isapprox(deltaangle(0.0, 1.0),  1.0)
-@test isapprox(deltaangle(0.0, 2π),  0.0, atol=1e-10)
-@test isapprox(deltaangle(0.0, π + 1.0), -(π- 1.0))
+let
+    @test isapprox(deltaangle(0.0, 0.0),  0.0)
+    @test isapprox(deltaangle(0.0, 1.0),  1.0)
+    @test isapprox(deltaangle(0.0, 2π),  0.0, atol=1e-10)
+    @test isapprox(deltaangle(0.0, π + 1.0), -(π- 1.0))
 
-@test isapprox(angledist(0.0, 0.0), 0.0)
-@test isapprox(angledist(0.0, 1.0), 1.0)
-@test isapprox(angledist(0.0, 2π), 0.0, atol=1e-10)
-@test isapprox(angledist(0.0, π + 1.0), π- 1.0)
+    @test isapprox(angledist(0.0, 0.0), 0.0)
+    @test isapprox(angledist(0.0, 1.0), 1.0)
+    @test isapprox(angledist(0.0, 2π), 0.0, atol=1e-10)
+    @test isapprox(angledist(0.0, π + 1.0), π- 1.0)
 
-@test isapprox(lerp_angle(0.0, 0.0, 1.0), 0.0)
-@test isapprox(lerp_angle(0.0, 2π, 0.5), 0.0, atol=1e-10)
-@test isapprox(lerp_angle(0.0, 2.0, 0.75),  1.5)
-@test isapprox(lerp_angle(0.0, 2π-2, 0.75), -1.5)
+    @test isapprox(lerp_angle(0.0, 0.0, 1.0), 0.0)
+    @test isapprox(lerp_angle(0.0, 2π, 0.5), 0.0, atol=1e-10)
+    @test isapprox(lerp_angle(0.0, 2.0, 0.75),  1.5)
+    @test isapprox(lerp_angle(0.0, 2π-2, 0.75), -1.5)
 
-@test are_collinear(VecE2(0.0,0.0), VecE2(1.0,1.0), VecE2(2.0,2.0))
-@test are_collinear(VecE2(0.0,0.0), VecE2(1.0,1.0), VecE2(-2.0,-2.0))
-@test are_collinear(VecE2(0.0,0.0), VecE2(0.5,1.0), VecE2(1.0,2.0))
-@test are_collinear(VecE2(1.0,2.0), VecE2(0.0,0.0), VecE2(0.5,1.0))
-@test !are_collinear(VecE2(0.0,0.0), VecE2(1.0,0.0), VecE2(0.0,1.0))
+    @test are_collinear(VecE2(0.0,0.0), VecE2(1.0,1.0), VecE2(2.0,2.0))
+    @test are_collinear(VecE2(0.0,0.0), VecE2(1.0,1.0), VecE2(-2.0,-2.0))
+    @test are_collinear(VecE2(0.0,0.0), VecE2(0.5,1.0), VecE2(1.0,2.0))
+    @test are_collinear(VecE2(1.0,2.0), VecE2(0.0,0.0), VecE2(0.5,1.0))
+    @test !are_collinear(VecE2(0.0,0.0), VecE2(1.0,0.0), VecE2(0.0,1.0))
+end
 
 let
     seg = LineSegment1D(0,1)
@@ -199,22 +201,24 @@ let
     # @test isapprox(d_PCA, 1.0)
 end
 
-@test  contains(Circ(0,0,1.0), VecE2(0,0))
-@test !contains(Circ(2,0,1.0), VecE2(0,0))
-@test  contains(Circ(2,0,1.0), VecE2(1.5,0))
-@test  contains(Circ(2,0,3,1.0), VecE3(1.5,0,3))
+let
+    @test  contains(Circ(0,0,1.0), VecE2(0,0))
+    @test !contains(Circ(2,0,1.0), VecE2(0,0))
+    @test  contains(Circ(2,0,1.0), VecE2(1.5,0))
+    @test  contains(Circ(2,0,3,1.0), VecE3(1.5,0,3))
 
-box = AABB(VecE2(0.0, 0.5), 2.0, 5.0)
-@test  contains(box, VecE2( 0.0,0.0))
-@test  contains(box, VecE2(-1.0,0.0))
-@test !contains(box, VecE2(-2.0,0.0))
-@test !contains(box, VecE2( 1.0,3.1))
+    box = AABB(VecE2(0.0, 0.5), 2.0, 5.0)
+    @test  contains(box, VecE2( 0.0,0.0))
+    @test  contains(box, VecE2(-1.0,0.0))
+    @test !contains(box, VecE2(-2.0,0.0))
+    @test !contains(box, VecE2( 1.0,3.1))
 
-box = AABB(VecE2(-1.0, -2.0), VecE2(1.0, 3.0))
-@test  contains(box, VecE2( 0.0,0.0))
-@test  contains(box, VecE2(-1.0,0.0))
-@test !contains(box, VecE2(-2.0,0.0))
-@test !contains(box, VecE2( 1.0,3.1))
+    box = AABB(VecE2(-1.0, -2.0), VecE2(1.0, 3.0))
+    @test  contains(box, VecE2( 0.0,0.0))
+    @test  contains(box, VecE2(-1.0,0.0))
+    @test !contains(box, VecE2(-2.0,0.0))
+    @test !contains(box, VecE2( 1.0,3.1))
+end
 
 let
     box = OBB(VecSE2(0.0, 0.5, 0.0), 2.0, 5.0)
@@ -280,5 +284,4 @@ let
     @test get_side(plane, VecE3(-1.0,0.0,0.0)) == -1
     @test get_side(plane, VecE3( 1.0,0.5,0.7)) ==  1
     @test get_side(plane, VecE3(-1.0,0.7,0.5)) == -1
-
 end

--- a/test/test_quat.jl
+++ b/test/test_quat.jl
@@ -1,4 +1,4 @@
-# let
+let
     q = Quat(1.0,2.0,3.0,4.5)
     @test length(q) == 4
     @test imag(q) == VecE3(1.0,2.0,3.0)
@@ -33,4 +33,4 @@
         @test norm(inv(q)*q - Quat(0,0,0,1)) < 1e-8
         @test norm(q*inv(q) - Quat(0,0,0,1)) < 1e-8
     end
-# end
+end

--- a/test/test_vecE2.jl
+++ b/test/test_vecE2.jl
@@ -1,121 +1,123 @@
-a = VecE2()
-@test typeof(a) <: VecE
-@test typeof(a) <: AbstractVec
-@test a.x == 0.0
-@test a.y == 0.0
+let
+	a = VecE2()
+	@test typeof(a) <: VecE
+	@test typeof(a) <: AbstractVec
+	@test a.x == 0.0
+	@test a.y == 0.0
 
-b = VecE2(0.0,0.0)
-@test b.x == 0.0
-@test b.y == 0.0
+	b = VecE2(0.0,0.0)
+	@test b.x == 0.0
+	@test b.y == 0.0
 
-@test length(a) == 2
-@test a == b
-@test isequal(a, b)
-@test copy(a) == a
-@test convert(Vector{Float64}, a) == [0.0,0.0]
-@test convert(VecE2, [0.0,0.0]) == a
+	@test length(a) == 2
+	@test a == b
+	@test isequal(a, b)
+	@test copy(a) == a
+	@test convert(Vector{Float64}, a) == [0.0,0.0]
+	@test convert(VecE2, [0.0,0.0]) == a
 
-@test isapprox(polar(1.0,0.0), VecE2(1.0,0.0))
-@test isapprox(polar(2.0,π/2), VecE2(0.0,2.0))
-@test isapprox(polar(3.0,-π/2), VecE2(0.0,-3.0))
-@test isapprox(polar(-0.5,1.0*π), VecE2(0.5,0.0))
+	@test isapprox(polar(1.0,0.0), VecE2(1.0,0.0))
+	@test isapprox(polar(2.0,π/2), VecE2(0.0,2.0))
+	@test isapprox(polar(3.0,-π/2), VecE2(0.0,-3.0))
+	@test isapprox(polar(-0.5,1.0*π), VecE2(0.5,0.0))
 
-a = VecE2(0.0,1.0)
-b = VecE2(0.5,2.0)
+	a = VecE2(0.0,1.0)
+	b = VecE2(0.5,2.0)
 
-@test a != b
+	@test a != b
 
-@test a + b == VecE2(0.5, 3.0)
-@test a + 1 == VecE2(1.0, 2.0)
-@test a + 0.5 == VecE2(0.5, 1.5)
+	@test a + b == VecE2(0.5, 3.0)
+	@test a + 1 == VecE2(1.0, 2.0)
+	@test a + 0.5 == VecE2(0.5, 1.5)
 
-@test a - b == VecE2(-0.5, -1.0)
-@test a - 1 == VecE2(-1.0,  0.0)
-@test a - 0.5 == VecE2(-0.5, 0.5)
+	@test a - b == VecE2(-0.5, -1.0)
+	@test a - 1 == VecE2(-1.0,  0.0)
+	@test a - 0.5 == VecE2(-0.5, 0.5)
 
-@test a * 2 == VecE2(0.0, 2.0)
-@test a * 0.5 == VecE2(0.0, 0.5)
+	@test a * 2 == VecE2(0.0, 2.0)
+	@test a * 0.5 == VecE2(0.0, 0.5)
 
-@test a / 2 == VecE2(0.0, 0.5)
-@test a / 0.5 == VecE2(0.0, 2.0)
+	@test a / 2 == VecE2(0.0, 0.5)
+	@test a / 0.5 == VecE2(0.0, 2.0)
 
-@test b.^2 == VecE2(0.25, 4.0)
-@test b.^0.5 == VecE2(0.5^0.5, 2.0^0.5)
+	@test b.^2 == VecE2(0.25, 4.0)
+	@test b.^0.5 == VecE2(0.5^0.5, 2.0^0.5)
 
-@test a.%2.0 == VecE2(0.0, 1.0)
+	@test a.%2.0 == VecE2(0.0, 1.0)
 
-@test isfinite(a)
-@test !isfinite(VecE2(Inf,0))
-@test !isfinite(VecE2(0,Inf))
-@test !isfinite(VecE2(0,-Inf))
-@test !isfinite(VecE2(Inf,Inf))
+	@test isfinite(a)
+	@test !isfinite(VecE2(Inf,0))
+	@test !isfinite(VecE2(0,Inf))
+	@test !isfinite(VecE2(0,-Inf))
+	@test !isfinite(VecE2(Inf,Inf))
 
-@test !isinf(a)
-@test isinf(VecE2(Inf,0))
-@test isinf(VecE2(0,Inf))
-@test isinf(VecE2(0,-Inf))
-@test isinf(VecE2(Inf,Inf))
+	@test !isinf(a)
+	@test isinf(VecE2(Inf,0))
+	@test isinf(VecE2(0,Inf))
+	@test isinf(VecE2(0,-Inf))
+	@test isinf(VecE2(Inf,Inf))
 
-@test !isnan(a)
-@test isnan(VecE2(NaN,0))
-@test isnan(VecE2(0,NaN))
-@test isnan(VecE2(NaN,NaN))
+	@test !isnan(a)
+	@test isnan(VecE2(NaN,0))
+	@test isnan(VecE2(0,NaN))
+	@test isnan(VecE2(NaN,NaN))
 
-@test round.(VecE2(0.25,1.75)) == VecE2(0.0,2.0)
-@test round.(VecE2(-0.25,-1.75)) == VecE2(-0.0,-2.0)
+	@test round.(VecE2(0.25,1.75)) == VecE2(0.0,2.0)
+	@test round.(VecE2(-0.25,-1.75)) == VecE2(-0.0,-2.0)
 
-@test floor.(VecE2(0.25,1.75)) == VecE2(0.0,1.0)
-@test floor.(VecE2(-0.25,-1.75)) == VecE2(-1.0,-2.0)
+	@test floor.(VecE2(0.25,1.75)) == VecE2(0.0,1.0)
+	@test floor.(VecE2(-0.25,-1.75)) == VecE2(-1.0,-2.0)
 
-@test ceil.(VecE2(0.25,1.75)) == VecE2(1.0,2.0)
-@test ceil.(VecE2(-0.25,-1.75)) == VecE2(-0.0,-1.0)
+	@test ceil.(VecE2(0.25,1.75)) == VecE2(1.0,2.0)
+	@test ceil.(VecE2(-0.25,-1.75)) == VecE2(-0.0,-1.0)
 
-@test trunc.(VecE2(0.25,1.75)) == VecE2(0.0,1.0)
-@test trunc.(VecE2(-0.25,-1.75)) == VecE2(-0.0,-1.0)
+	@test trunc.(VecE2(0.25,1.75)) == VecE2(0.0,1.0)
+	@test trunc.(VecE2(-0.25,-1.75)) == VecE2(-0.0,-1.0)
 
-@test clamp.(VecE2(1.0, 10.0), 0.0, 5.0) == VecE2(1.0, 5.0)
-@test clamp.(VecE2(-1.0, 4.0), 0.0, 5.0) == VecE2(0.0, 4.0)
+	@test clamp.(VecE2(1.0, 10.0), 0.0, 5.0) == VecE2(1.0, 5.0)
+	@test clamp.(VecE2(-1.0, 4.0), 0.0, 5.0) == VecE2(0.0, 4.0)
 
-c = VecE2(3.0,4.0)
+	c = VecE2(3.0,4.0)
 
-@test isapprox(abs.(a), VecE2(0.0, 1.0))
-@test isapprox(abs.(c), VecE2(3.0, 4.0))
-@test isapprox(norm(a), 1.0)
-@test isapprox(norm(c), 5.0)
-@test isapprox(normalize(a), VecE2(0.0,1.0))
-@test isapprox(normalize(b), VecE2(0.5/sqrt(4.25),2.0/sqrt(4.25)))
-@test isapprox(normalize(c), VecE2(3.0/5,4.0/5))
+	@test isapprox(abs.(a), VecE2(0.0, 1.0))
+	@test isapprox(abs.(c), VecE2(3.0, 4.0))
+	@test isapprox(norm(a), 1.0)
+	@test isapprox(norm(c), 5.0)
+	@test isapprox(normalize(a), VecE2(0.0,1.0))
+	@test isapprox(normalize(b), VecE2(0.5/sqrt(4.25),2.0/sqrt(4.25)))
+	@test isapprox(normalize(c), VecE2(3.0/5,4.0/5))
 
-@test isapprox(dist(a,a), 0.0)
-@test isapprox(dist(b,b), 0.0)
-@test isapprox(dist(c,c), 0.0)
-@test isapprox(dist(a,b), hypot(0.5, 1.0))
-@test isapprox(dist(a,c), hypot(3.0, 3.0))
+	@test isapprox(dist(a,a), 0.0)
+	@test isapprox(dist(b,b), 0.0)
+	@test isapprox(dist(c,c), 0.0)
+	@test isapprox(dist(a,b), hypot(0.5, 1.0))
+	@test isapprox(dist(a,c), hypot(3.0, 3.0))
 
-@test isapprox(dist2(a,a), 0.0)
-@test isapprox(dist2(b,b), 0.0)
-@test isapprox(dist2(c,c), 0.0)
-@test isapprox(dist2(a,b), 0.5^2 + 1^2)
-@test isapprox(dist2(a,c), 3^2 + 3^2)
+	@test isapprox(dist2(a,a), 0.0)
+	@test isapprox(dist2(b,b), 0.0)
+	@test isapprox(dist2(c,c), 0.0)
+	@test isapprox(dist2(a,b), 0.5^2 + 1^2)
+	@test isapprox(dist2(a,c), 3^2 + 3^2)
 
-@test isapprox(dot(a, b), 2.0)
-@test isapprox(dot(b, c), 1.5 + 8.0)
-@test isapprox(dot(c, c), norm(c)^2)
+	@test isapprox(dot(a, b), 2.0)
+	@test isapprox(dot(b, c), 1.5 + 8.0)
+	@test isapprox(dot(c, c), norm(c)^2)
 
-@test isapprox(proj(b, a, Float64), 2.0)
-@test isapprox(proj(c, a, Float64), 4.0)
+	@test isapprox(proj(b, a, Float64), 2.0)
+	@test isapprox(proj(c, a, Float64), 4.0)
 
-@test isapprox(proj(b, a, VecE2), VecE2(0.0, 2.0))
-@test isapprox(proj(c, a, VecE2), VecE2(0.0, 4.0))
+	@test isapprox(proj(b, a, VecE2), VecE2(0.0, 2.0))
+	@test isapprox(proj(c, a, VecE2), VecE2(0.0, 4.0))
 
-@test isapprox(lerp(VecE2(0,0), VecE2(2,-2), 0.25), VecE2(0.5,-0.5))
-@test isapprox(lerp(VecE2(2,-2), VecE2(3,-3), 0.5), VecE2(2.5,-2.5))
+	@test isapprox(lerp(VecE2(0,0), VecE2(2,-2), 0.25), VecE2(0.5,-0.5))
+	@test isapprox(lerp(VecE2(2,-2), VecE2(3,-3), 0.5), VecE2(2.5,-2.5))
 
-@test isapprox(rot180(b), VecE2(-0.5,-2.0))
-@test isapprox(rotr90(b), VecE2( 2.0,-0.5))
-@test isapprox(rotl90(b), VecE2(-2.0, 0.5))
+	@test isapprox(rot180(b), VecE2(-0.5,-2.0))
+	@test isapprox(rotr90(b), VecE2( 2.0,-0.5))
+	@test isapprox(rotl90(b), VecE2(-2.0, 0.5))
 
-@test isapprox(rot(b, 1.0*pi), VecE2(-0.5,-2.0))
-@test isapprox(rot(b, -π/2), VecE2( 2.0,-0.5))
-@test isapprox(rot(b,  π/2), VecE2(-2.0, 0.5))
-@test isapprox(rot(b, 2π), b)
+	@test isapprox(rot(b, 1.0*pi), VecE2(-0.5,-2.0))
+	@test isapprox(rot(b, -π/2), VecE2( 2.0,-0.5))
+	@test isapprox(rot(b,  π/2), VecE2(-2.0, 0.5))
+	@test isapprox(rot(b, 2π), b)
+end

--- a/test/test_vecE3.jl
+++ b/test/test_vecE3.jl
@@ -1,127 +1,125 @@
-a = VecE3()
-@test typeof(a) <: VecE3
-@test typeof(a) <: AbstractVec
-@test a.x == 0.0
-@test a.y == 0.0
-@test a.z == 0.0
+let
+	a = VecE3()
+	@test typeof(a) <: VecE3
+	@test typeof(a) <: AbstractVec
+	@test a.x == 0.0
+	@test a.y == 0.0
+	@test a.z == 0.0
 
-b = VecE3(0.0,0.0,0.0)
-@test b.x == 0.0
-@test b.y == 0.0
-@test b.z == 0.0
+	b = VecE3(0.0,0.0,0.0)
+	@test b.x == 0.0
+	@test b.y == 0.0
+	@test b.z == 0.0
 
-@test length(a) == 3
-@test a == b
-@test isequal(a, b)
-@test copy(a) == a
-@test convert(Vector{Float64}, a) == [0.0,0.0,0.0]
-@test convert(VecE3, [0.0,0.0,0.0]) == a
+	@test length(a) == 3
+	@test a == b
+	@test isequal(a, b)
+	@test copy(a) == a
+	@test convert(Vector{Float64}, a) == [0.0,0.0,0.0]
+	@test convert(VecE3, [0.0,0.0,0.0]) == a
 
-# @test isapprox(polar(1.0,0.0,0.0), VecE3(1.0,0.0,0.0))
-# @test isapprox(polar(2.0,π/2,1.0), VecE3(0.0,2.0,1.0))
-# @test isapprox(polar(3.0,-π/2,-0.5), VecE3(0.0,-3.0,-0.5))
-# @test isapprox(polar(-0.5,1.0*π,1.0*π), VecE3(0.5,0.0,1.0*π))
+	@test isapprox(polar(1.0,0.0,0.0), VecE3(1.0,0.0,0.0))
+	@test isapprox(polar(2.0,π/2,1.0), VecE3(0.0,2.0,1.0))
+	@test isapprox(polar(3.0,-π/2,-0.5), VecE3(0.0,-3.0,-0.5))
+	@test isapprox(polar(-0.5,1.0*π,1.0*π), VecE3(0.5,0.0,1.0*π))
 
-a = VecE3(0.0,1.0, 2.0)
-b = VecE3(0.5,2.0,-3.0)
+	a = VecE3(0.0,1.0, 2.0)
+	b = VecE3(0.5,2.0,-3.0)
 
-@test a != b
+	@test a != b
 
-@test a + b == VecE3(0.5, 3.0, -1.0)
-@test a + 1 == VecE3(1.0, 2.0,  3.0)
-@test a + 0.5 == VecE3(0.5, 1.5, 2.5)
+	@test a + b == VecE3(0.5, 3.0, -1.0)
+	@test a + 1 == VecE3(1.0, 2.0,  3.0)
+	@test a + 0.5 == VecE3(0.5, 1.5, 2.5)
 
-@test a - b == VecE3(-0.5, -1.0, 5.0)
-@test a - 1 == VecE3(-1.0,  0.0, 1.0)
-@test a - 0.5 == VecE3(-0.5, 0.5, 1.5)
+	@test a - b == VecE3(-0.5, -1.0, 5.0)
+	@test a - 1 == VecE3(-1.0,  0.0, 1.0)
+	@test a - 0.5 == VecE3(-0.5, 0.5, 1.5)
 
-@test a * 2 == VecE3(0.0, 2.0, 4.0)
-@test a * 0.5 == VecE3(0.0, 0.5, 1.0)
+	@test a * 2 == VecE3(0.0, 2.0, 4.0)
+	@test a * 0.5 == VecE3(0.0, 0.5, 1.0)
 
-@test a / 2 == VecE3(0.0, 0.5, 1.0)
-@test a / 0.5 == VecE3(0.0, 2.0, 4.0)
+	@test a / 2 == VecE3(0.0, 0.5, 1.0)
+	@test a / 0.5 == VecE3(0.0, 2.0, 4.0)
 
-@test b.^2 == VecE3(0.25, 4.0, 9.0)
-@test VecE3(0.5, 2.0, 3.0).^0.5 == VecE3(0.5^0.5, 2.0^0.5, 3.0^0.5)
+	@test b.^2 == VecE3(0.25, 4.0, 9.0)
+	@test VecE3(0.5, 2.0, 3.0).^0.5 == VecE3(0.5^0.5, 2.0^0.5, 3.0^0.5)
 
-# @test a % 2.0 == VecE3(0.0, 1.0, 0.0)
-# @test a % 2 == VecE3(0.0, 1.0, 0.0)
+	@test isfinite(a)
+	@test !isfinite(VecE3(Inf,0,0))
+	@test !isfinite(VecE3(0,Inf,0))
+	@test !isfinite(VecE3(0,-Inf,0))
+	@test !isfinite(VecE3(Inf,Inf,Inf))
 
-@test isfinite(a)
-@test !isfinite(VecE3(Inf,0,0))
-@test !isfinite(VecE3(0,Inf,0))
-@test !isfinite(VecE3(0,-Inf,0))
-@test !isfinite(VecE3(Inf,Inf,Inf))
+	@test !isinf(a)
+	@test isinf(VecE3(Inf,0,0))
+	@test isinf(VecE3(0,Inf,0))
+	@test isinf(VecE3(0,-Inf,0))
+	@test isinf(VecE3(Inf,Inf,Inf))
 
-@test !isinf(a)
-@test isinf(VecE3(Inf,0,0))
-@test isinf(VecE3(0,Inf,0))
-@test isinf(VecE3(0,-Inf,0))
-@test isinf(VecE3(Inf,Inf,Inf))
+	@test !isnan(a)
+	@test isnan(VecE3(NaN,0,NaN))
+	@test isnan(VecE3(0,NaN,NaN))
+	@test isnan(VecE3(NaN,NaN,NaN))
 
-@test !isnan(a)
-@test isnan(VecE3(NaN,0,NaN))
-@test isnan(VecE3(0,NaN,NaN))
-@test isnan(VecE3(NaN,NaN,NaN))
+	@test round.(VecE3(0.25,1.75,0)) == VecE3(0.0,2.0,0.0)
+	@test round.(VecE3(-0.25,-1.75,0)) == VecE3(-0.0,-2.0,0.0)
 
-@test round.(VecE3(0.25,1.75,0)) == VecE3(0.0,2.0,0.0)
-@test round.(VecE3(-0.25,-1.75,0)) == VecE3(-0.0,-2.0,0.0)
+	@test floor.(VecE3(0.25,1.75,0.0)) == VecE3(0.0,1.0,0.0)
+	@test floor.(VecE3(-0.25,-1.75,0.0)) == VecE3(-1.0,-2.0,0.0)
 
-@test floor.(VecE3(0.25,1.75,0.0)) == VecE3(0.0,1.0,0.0)
-@test floor.(VecE3(-0.25,-1.75,0.0)) == VecE3(-1.0,-2.0,0.0)
+	@test ceil.(VecE3(0.25,1.75,0.0)) == VecE3(1.0,2.0,0.0)
+	@test ceil.(VecE3(-0.25,-1.75,0.0)) == VecE3(-0.0,-1.0,0.0)
 
-@test ceil.(VecE3(0.25,1.75,0.0)) == VecE3(1.0,2.0,0.0)
-@test ceil.(VecE3(-0.25,-1.75,0.0)) == VecE3(-0.0,-1.0,0.0)
+	@test trunc.(VecE3(0.25,1.75,0.0)) == VecE3(0.0,1.0,0.0)
+	@test trunc.(VecE3(-0.25,-1.75,0.0)) == VecE3(-0.0,-1.0,0.0)
 
-@test trunc.(VecE3(0.25,1.75,0.0)) == VecE3(0.0,1.0,0.0)
-@test trunc.(VecE3(-0.25,-1.75,0.0)) == VecE3(-0.0,-1.0,0.0)
+	@test clamp.(VecE3(1.0, 10.0, 0.5), 0.0, 5.0) == VecE3(1.0, 5.0, 0.5)
+	@test clamp.(VecE3(-1.0, 4.0, 5.5), 0.0, 5.0) == VecE3(0.0, 4.0, 5.0)
 
-@test clamp.(VecE3(1.0, 10.0, 0.5), 0.0, 5.0) == VecE3(1.0, 5.0, 0.5)
-@test clamp.(VecE3(-1.0, 4.0, 5.5), 0.0, 5.0) == VecE3(0.0, 4.0, 5.0)
+	c = VecE3(3.0,4.0,5.0)
 
-c = VecE3(3.0,4.0,5.0)
+	@test isapprox(abs.(a), a)
+	@test isapprox(abs.(c), c)
+	@test isapprox(norm(c), sqrt(3^2 + 4^2 + 5^2))
+	@test isapprox(normalize(a), VecE3(0.0,1.0/hypot(1.0,2.0), 2.0/hypot(1.0,2.0)))
 
-@test isapprox(abs.(a), a)
-@test isapprox(abs.(c), c)
-@test isapprox(norm(c), sqrt(3^2 + 4^2 + 5^2))
-@test isapprox(normalize(a), VecE3(0.0,1.0/hypot(1.0,2.0), 2.0/hypot(1.0,2.0)))
+	@test isapprox(dist(a,a), 0.0)
+	@test isapprox(dist(b,b), 0.0)
+	@test isapprox(dist(c,c), 0.0)
+	@test isapprox(dist(a,b), norm([0.5, 1.0, 5.0]))
+	@test isapprox(dist(a,c), norm([3.0, 3.0, 3.0]))
 
-@test isapprox(dist(a,a), 0.0)
-@test isapprox(dist(b,b), 0.0)
-@test isapprox(dist(c,c), 0.0)
-@test isapprox(dist(a,b), norm([0.5, 1.0, 5.0]))
-@test isapprox(dist(a,c), norm([3.0, 3.0, 3.0]))
+	@test isapprox(dist2(a,a), 0.0)
+	@test isapprox(dist2(b,b), 0.0)
+	@test isapprox(dist2(c,c), 0.0)
+	@test isapprox(dist2(a,b), 0.5^2 + 1^2 + 5^2)
+	@test isapprox(dist2(a,c), 3^2 + 3^2 + 3^2)
 
-@test isapprox(dist2(a,a), 0.0)
-@test isapprox(dist2(b,b), 0.0)
-@test isapprox(dist2(c,c), 0.0)
-@test isapprox(dist2(a,b), 0.5^2 + 1^2 + 5^2)
-@test isapprox(dist2(a,c), 3^2 + 3^2 + 3^2)
+	@test isapprox(dot(a, b), 2.0 - 6.0)
+	@test isapprox(dot(b, c), 1.5 + 8.0 - 15.0)
+	@test isapprox(dot(c, c), norm(c)^2)
 
-@test isapprox(dot(a, b), 2.0 - 6.0)
-@test isapprox(dot(b, c), 1.5 + 8.0 - 15.0)
-@test isapprox(dot(c, c), norm(c)^2)
+	@test isapprox(proj(b, a, Float64), -norm(VecE3(0.0, -0.8, -1.6)))
+	@test isapprox(proj(c, a, Float64),  norm(VecE3(0.0,  2.8,  5.6)))
 
-@test isapprox(proj(b, a, Float64), -norm(VecE3(0.0, -0.8, -1.6)))
-@test isapprox(proj(c, a, Float64),  norm(VecE3(0.0,  2.8,  5.6)))
+	@test isapprox(proj(b, a, VecE3), VecE3(0.0, -0.8, -1.6))
+	@test isapprox(proj(c, a, VecE3), VecE3(0.0,  2.8,  5.6))
 
-@test isapprox(proj(b, a, VecE3), VecE3(0.0, -0.8, -1.6))
-@test isapprox(proj(c, a, VecE3), VecE3(0.0,  2.8,  5.6))
+	@test isapprox(lerp(VecE3(0,0,0), VecE3(2,-2,2), 0.25), VecE3(0.5,-0.5,0.5))
+	@test isapprox(lerp(VecE3(2,-2,2), VecE3(3,-3,3), 0.5), VecE3(2.5,-2.5,2.5))
 
-@test isapprox(lerp(VecE3(0,0,0), VecE3(2,-2,2), 0.25), VecE3(0.5,-0.5,0.5))
-@test isapprox(lerp(VecE3(2,-2,2), VecE3(3,-3,3), 0.5), VecE3(2.5,-2.5,2.5))
+	@test isapprox(rot(VecE3(1,2,3), VecE3(2,0,0), 0.0), VecE3(1,2,3))
+	@test isapprox(rot(VecE3(1,2,3), VecE3(2,0,0), π/2), VecE3(1,-3,2))
+	@test isapprox(rot(VecE3(1,2,3), VecE3(2,0,0), -π/2), VecE3(1,3,-2))
+	@test isapprox(rot(VecE3(1,2,3), VecE3(2,0,0), 1.0π), VecE3(1,-2,-3))
+	@test isapprox(rot(VecE3(1,2,3), VecE3(0,2,0), π/2), VecE3(3,2,-1))
+	@test isapprox(rot(VecE3(1,2,3), VecE3(0,0,2), π/2), VecE3(-2,1,3))
 
-@test isapprox(rot(VecE3(1,2,3), VecE3(2,0,0), 0.0), VecE3(1,2,3))
-@test isapprox(rot(VecE3(1,2,3), VecE3(2,0,0), π/2), VecE3(1,-3,2))
-@test isapprox(rot(VecE3(1,2,3), VecE3(2,0,0), -π/2), VecE3(1,3,-2))
-@test isapprox(rot(VecE3(1,2,3), VecE3(2,0,0), 1.0π), VecE3(1,-2,-3))
-@test isapprox(rot(VecE3(1,2,3), VecE3(0,2,0), π/2), VecE3(3,2,-1))
-@test isapprox(rot(VecE3(1,2,3), VecE3(0,0,2), π/2), VecE3(-2,1,3))
-
-@test isapprox(rot_normalized(VecE3(1,2,3), VecE3(1,0,0), 0.0), VecE3(1,2,3))
-@test isapprox(rot_normalized(VecE3(1,2,3), VecE3(1,0,0), π/2), VecE3(1,-3,2))
-@test isapprox(rot_normalized(VecE3(1,2,3), VecE3(1,0,0), -π/2), VecE3(1,3,-2))
-@test isapprox(rot_normalized(VecE3(1,2,3), VecE3(1,0,0), 1.0π), VecE3(1,-2,-3))
-@test isapprox(rot_normalized(VecE3(1,2,3), VecE3(0,1,0), π/2), VecE3(3,2,-1))
-@test isapprox(rot_normalized(VecE3(1,2,3), VecE3(0,0,1), π/2), VecE3(-2,1,3))
-
+	@test isapprox(rot_normalized(VecE3(1,2,3), VecE3(1,0,0), 0.0), VecE3(1,2,3))
+	@test isapprox(rot_normalized(VecE3(1,2,3), VecE3(1,0,0), π/2), VecE3(1,-3,2))
+	@test isapprox(rot_normalized(VecE3(1,2,3), VecE3(1,0,0), -π/2), VecE3(1,3,-2))
+	@test isapprox(rot_normalized(VecE3(1,2,3), VecE3(1,0,0), 1.0π), VecE3(1,-2,-3))
+	@test isapprox(rot_normalized(VecE3(1,2,3), VecE3(0,1,0), π/2), VecE3(3,2,-1))
+	@test isapprox(rot_normalized(VecE3(1,2,3), VecE3(0,0,1), π/2), VecE3(-2,1,3))
+end

--- a/test/test_vecSE2.jl
+++ b/test/test_vecSE2.jl
@@ -1,138 +1,87 @@
-a = VecSE2()
-@test typeof(a) <: VecSE
-@test typeof(a) <: AbstractVec
-@test a.x == 0.0
-@test a.y == 0.0
-@test a.θ == 0.0
+let
+	a = VecSE2()
+	@test typeof(a) <: VecSE
+	@test typeof(a) <: AbstractVec
+	@test a.x == 0.0
+	@test a.y == 0.0
+	@test a.θ == 0.0
 
-b = VecSE2(0.0,0.0,0.0)
-@test b.x == 0.0
-@test b.y == 0.0
-@test b.θ == 0.0
+	b = VecSE2(0.0,0.0,0.0)
+	@test b.x == 0.0
+	@test b.y == 0.0
+	@test b.θ == 0.0
 
-c = VecSE2(VecE2(0.0,0.0),0.0)
-@test c.x == 0.0
-@test c.y == 0.0
-@test c.θ == 0.0
+	c = VecSE2(VecE2(0.0,0.0),0.0)
+	@test c.x == 0.0
+	@test c.y == 0.0
+	@test c.θ == 0.0
 
-@test length(a) == 3
-@test a == b
-@test b == c
-@test a == c
-@test isequal(b, a)
-@test copy(a) == a
-@test convert(Vector{Float64}, a) == [0.0,0.0,0.0]
-@test convert(VecSE2, [1.0,2.0,3.0]) == VecSE2(1.0,2.0,3.0)
-@test convert(VecE2, VecSE2(1.0,2.0,3.0)) == VecE2(1.0,2.0)
+	@test length(a) == 3
+	@test a == b
+	@test b == c
+	@test a == c
+	@test isequal(b, a)
+	@test copy(a) == a
+	@test convert(Vector{Float64}, a) == [0.0,0.0,0.0]
+	@test convert(VecSE2, [1.0,2.0,3.0]) == VecSE2(1.0,2.0,3.0)
+	@test convert(VecE2, VecSE2(1.0,2.0,3.0)) == VecE2(1.0,2.0)
 
-@test isapprox(polar( 1.0, 0.0, 0.5), VecSE2(1.0,0.0,0.5))
-@test isapprox(polar( 2.0, π/2,-0.5), VecSE2(0.0,2.0,-0.5))
-@test isapprox(polar( 3.0,-π/2,   1), VecSE2(0.0,-3.0,1.0))
-@test isapprox(polar(-0.5,  1π, -1), VecSE2(0.5,0.0,-1))
+	@test isapprox(polar( 1.0, 0.0, 0.5), VecSE2(1.0,0.0,0.5))
+	@test isapprox(polar( 2.0, π/2,-0.5), VecSE2(0.0,2.0,-0.5))
+	@test isapprox(polar( 3.0,-π/2,   1), VecSE2(0.0,-3.0,1.0))
+	@test isapprox(polar(-0.5,  1π, -1), VecSE2(0.5,0.0,-1))
 
-a = VecSE2(0.0,1.0,π/2)
-b = VecSE2(0.5,2.0,-π)
-unit_e2 = VecE2(1.0, 1.0)
+	a = VecSE2(0.0,1.0,π/2)
+	b = VecSE2(0.5,2.0,-π)
+	unit_e2 = VecE2(1.0, 1.0)
 
-@test a != b
+	@test a != b
 
-@test a + b == VecSE2(0.5, 3.0, -π/2)
-@test a + 1*unit_e2 == VecSE2(1.0, 2.0,  π/2)
-@test a + 0.5*unit_e2 == VecSE2(0.5, 1.5, π/2)
-@test 1*unit_e2 + a == VecSE2(1.0, 2.0,  π/2)
-@test 0.5*unit_e2 + a == VecSE2(0.5, 1.5, π/2)
+	@test a + b == VecSE2(0.5, 3.0, -π/2)
+	@test a + 1*unit_e2 == VecSE2(1.0, 2.0,  π/2)
+	@test a + 0.5*unit_e2 == VecSE2(0.5, 1.5, π/2)
+	@test 1*unit_e2 + a == VecSE2(1.0, 2.0,  π/2)
+	@test 0.5*unit_e2 + a == VecSE2(0.5, 1.5, π/2)
 
-@test a - b == VecSE2(-0.5, -1.0, 3π/2)
-@test a - 1*unit_e2 == VecSE2(-1.0,  0.0,  π/2)
-@test a - 0.5*unit_e2 == VecSE2(-0.5, 0.5, π/2)
-@test 1*unit_e2 - a == VecSE2(1.0,  0.0, -π/2)
-@test 0.5*unit_e2 - a == VecSE2(0.5, -0.5, -π/2)
+	@test a - b == VecSE2(-0.5, -1.0, 3π/2)
+	@test a - 1*unit_e2 == VecSE2(-1.0,  0.0,  π/2)
+	@test a - 0.5*unit_e2 == VecSE2(-0.5, 0.5, π/2)
+	@test 1*unit_e2 - a == VecSE2(1.0,  0.0, -π/2)
+	@test 0.5*unit_e2 - a == VecSE2(0.5, -0.5, -π/2)
 
-@test scale_euclidean(a, 2) == VecSE2(0.0, 2.0, π/2)
-@test scale_euclidean(a, 0.5) == VecSE2(0.0, 0.5, π/2)
+	@test scale_euclidean(a, 2) == VecSE2(0.0, 2.0, π/2)
+	@test scale_euclidean(a, 0.5) == VecSE2(0.0, 0.5, π/2)
 
-@test scale_euclidean(a, 1/2) == VecSE2(0.0, 0.5, π/2)
-@test scale_euclidean(a, 1/0.5) == VecSE2(0.0, 2.0, π/2)
+	@test scale_euclidean(a, 1/2) == VecSE2(0.0, 0.5, π/2)
+	@test scale_euclidean(a, 1/0.5) == VecSE2(0.0, 2.0, π/2)
 
-# @test b^2 == VecSE2(0.25, 4.0, -π)
-# @test b^0.5 == VecSE2(0.5^0.5, 2.0^0.5, -π)
-# 
-# @test a % 2.0 == VecSE2(0.0, 1.0, π/2)
+	@test clamp_euclidean(VecSE2(1.0, 10.0, 0.5), 0.0, 5.0) == VecSE2(1.0, 5.0, 0.5)
+	@test clamp_euclidean(VecSE2(-1.0, 4.0, 5.5), 0.0, 5.0) == VecSE2(0.0, 4.0, 5.5)
 
-@test clamp_euclidean(VecSE2(1.0, 10.0, 0.5), 0.0, 5.0) == VecSE2(1.0, 5.0, 0.5)
-@test clamp_euclidean(VecSE2(-1.0, 4.0, 5.5), 0.0, 5.0) == VecSE2(0.0, 4.0, 5.5)
+	@test isfinite(a)
+	@test !isfinite(VecSE2(Inf,0))
+	@test !isfinite(VecSE2(0,Inf))
+	@test !isfinite(VecSE2(0,-Inf))
+	@test !isfinite(VecSE2(Inf,Inf))
 
-@test isfinite(a)
-@test !isfinite(VecSE2(Inf,0))
-@test !isfinite(VecSE2(0,Inf))
-@test !isfinite(VecSE2(0,-Inf))
-@test !isfinite(VecSE2(Inf,Inf))
+	@test !isinf(a)
+	@test isinf(VecSE2(Inf,0))
+	@test isinf(VecSE2(0,Inf))
+	@test isinf(VecSE2(0,-Inf))
+	@test isinf(VecSE2(Inf,Inf))
 
-@test !isinf(a)
-@test isinf(VecSE2(Inf,0))
-@test isinf(VecSE2(0,Inf))
-@test isinf(VecSE2(0,-Inf))
-@test isinf(VecSE2(Inf,Inf))
+	@test !isnan(a)
+	@test isnan(VecSE2(NaN,0))
+	@test isnan(VecSE2(0,NaN))
+	@test isnan(VecSE2(NaN,NaN))
 
-@test !isnan(a)
-@test isnan(VecSE2(NaN,0))
-@test isnan(VecSE2(0,NaN))
-@test isnan(VecSE2(NaN,NaN))
+	c = VecSE2(3.0,4.0)
 
-# @test round(VecSE2(0.25,1.75)) == VecSE2(0.0,2.0)
-# @test round(VecSE2(-0.25,-1.75)) == VecSE2(-0.0,-2.0)
+	@test isapprox(norm(VecE2(a)), 1.0)
+	@test isapprox(norm(VecE2(b)), hypot(0.5, 2.0))
+	@test isapprox(norm(VecE2(c)), hypot(3.0, 4.0))
 
-# @test floor(VecSE2(0.25,1.75)) == VecSE2(0.0,1.0)
-# @test floor(VecSE2(-0.25,-1.75)) == VecSE2(-1.0,-2.0)
-
-# @test ceil(VecSE2(0.25,1.75)) == VecSE2(1.0,2.0)
-# @test ceil(VecSE2(-0.25,-1.75)) == VecSE2(-0.0,-1.0)
-
-# @test trunc(VecSE2(0.25,1.75)) == VecSE2(0.0,1.0)
-# @test trunc(VecSE2(-0.25,-1.75)) == VecSE2(-0.0,-1.0)
-
-# c = VecSE2(3.0,4.0)
-
-# @test isapprox(abs(a), 1.0)
-# @test isapprox(abs(c), 5.0)
-# @test isapprox(hypot(a), 1.0)
-# @test isapprox(hypot(c), 5.0)
-# @test isapprox(abs2(a), 1.0)
-# @test isapprox(abs2(c), 25.0)
-# @test isapprox(norm(a), VecSE2(0.0,1.0))
-# @test isapprox(norm(b), VecSE2(0.5/sqrt(4.25),2.0/sqrt(4.25)))
-# @test isapprox(norm(c), VecSE2(3.0/5,4.0/5))
-
-# @test isapprox(dist(a,a), 0.0)
-# @test isapprox(dist(b,b), 0.0)
-# @test isapprox(dist(c,c), 0.0)
-# @test isapprox(dist(a,b), hypot(0.5, 1.0))
-# @test isapprox(dist(a,c), hypot(3.0, 3.0))
-
-# @test isapprox(dist2(a,a), 0.0)
-# @test isapprox(dist2(b,b), 0.0)
-# @test isapprox(dist2(c,c), 0.0)
-# @test isapprox(dist2(a,b), 0.5^2 + 1^2)
-# @test isapprox(dist2(a,c), 3^2 + 3^2)
-
-# @test isapprox(dot(a, b), 2.0)
-# @test isapprox(dot(b, c), 1.5 + 8.0)
-# @test isapprox(dot(c, c), abs2(c))
-
-# @test isapprox(proj(b, a, Float64), 2.0)
-# @test isapprox(proj(c, a, Float64), 4.0)
-
-# @test isapprox(proj(b, a, VecSE2), VecSE2(0.0, 2.0))
-# @test isapprox(proj(c, a, VecSE2), VecSE2(0.0, 4.0))
-
-# @test isapprox(lerp(VecSE2(0,0), VecSE2(2,-2), 0.25), VecSE2(0.5,-0.5))
-# @test isapprox(lerp(VecSE2(2,-2), VecSE2(3,-3), 0.5), VecSE2(2.5,-2.5))
-
-# @test isapprox(rot180(b), VecSE2(-0.5,-2.0))
-# @test isapprox(rotr90(b), VecSE2( 2.0,-0.5))
-# @test isapprox(rotl90(b), VecSE2(-2.0, 0.5))
-
-# @test isapprox(rot(b, 1.0*pi), VecSE2(-0.5,-2.0))
-# @test isapprox(rot(b, -π/2), VecSE2( 2.0,-0.5))
-# @test isapprox(rot(b,  π/2), VecSE2(-2.0, 0.5))
-# @test isapprox(rot(b, 2π), b)
+	@test isapprox(normalize(VecE2(a)), VecE2(0.0,1.0))
+	@test isapprox(normalize(VecE2(b)), VecE2(0.5/sqrt(4.25),2.0/sqrt(4.25)))
+	@test isapprox(normalize(VecE2(c)), VecE2(3.0/5,4.0/5))
+end


### PR DESCRIPTION
Upgrading Vec.jl to support Julia 0.7. Is not backwards compatible. 
Now also using the symbols for cross and dot rather than the named functions.