### PR TITLE
update StaticArrays.similar_type()

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -3,7 +3,7 @@ const DUMMY_PRECISION = 1e-12
 Base.isfinite(a::AbstractVec) = all(isfinite.(a))
 Base.isinf(a::AbstractVec) = any(isinf.(a))
 
-function StaticArrays.similar_type(::Type{V}, ::Type{F}, size::Size{N}) where {V<:VecE, F<:AbstractFloat, N}
+function StaticArrays.similar_type(::Type{V}, ::Type{F}, size::Size{N}) where {V<:AbstractVec, F<:AbstractFloat, N}
     if size == Size(V) && eltype(V) == F
         return V
     else # convert back to SArray

--- a/src/common.jl
+++ b/src/common.jl
@@ -3,12 +3,11 @@ const DUMMY_PRECISION = 1e-12
 Base.isfinite(a::AbstractVec) = all(isfinite.(a))
 Base.isinf(a::AbstractVec) = any(isinf.(a))
 
-function StaticArrays.similar_type(::Type{V}, ::Type{F}, size::Size) where {V<:AbstractVec, F<:AbstractFloat}
-    # TODO: implement this for other types
+function StaticArrays.similar_type(::Type{V}, ::Type{F}, size::Size{N}) where {V<:VecE, F<:AbstractFloat, N}
     if size == Size(V) && eltype(V) == F
         return V
-    else
-        error("StaticArrays.similar_type is not yet implemented for Vec except for Float64 and matching size.")
+    else # convert back to SArray
+        return SArray{Tuple{N...},F,length(size),prod(size)}
     end
 end
 


### PR DESCRIPTION
similar_type now returns the corresponding SArray if size doesn't match. This allows you to do ``` hcat(VecE2(0.0,0.0),VecE2(0.0,0.0)) ```, for example. This will need to be extended to handle conversion between parametric types of the same size, but I think this makes sense as a default for now.